### PR TITLE
Fix commit message sanitization

### DIFF
--- a/server.js
+++ b/server.js
@@ -296,8 +296,11 @@ const genDir = path.join(__dirname, 'gen');
 async function commitFilesTogether(logFilePath, htmlFilePath, assistantMessage) {
   // ログファイル名からプロジェクト名を抽出（例: gen/log/[projectName].json -> projectName）
   const projectName = path.basename(logFilePath, '.json');
-  // シンプルなサニタイズ例：シングルクォートを削除
-  const sanitizedMessage = assistantMessage.trim().replace(/'/g, "");
+  // コミットメッセージでシェル展開が起こらないように不要な文字を除去
+  const sanitizedMessage = assistantMessage
+    .trim()
+    .replace(/["']/g, "")
+    .replace(/\r?\n/g, " ");
   // コミットメッセージの先頭行にプロジェクト名を追加
   const commitMsg = `${projectName}: ${sanitizedMessage}`;
   


### PR DESCRIPTION
## Summary
- sanitize newline and quotes in commit messages to avoid shell issues

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68400d5ef0f88322b57888c8a3325e29