### PR TITLE
Read OpenAI settings from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,17 @@
 
 ```env
 OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+OPENAI_MODEL=o3-mini
+REASONING_EFFORT=high
 PORT=3000
 GIT_AUTO_COMMIT=false
 ```
 
-- `OPENAI_API_KEY` は発行された実際の API キーに置き換えてください。  
-- `GIT_AUTO_COMMIT` は Git 自動コミットを行うかどうかの設定です。  
-	デフォルトは `false` で、必要に応じて `true` に設定してください。  
+- `OPENAI_API_KEY` は発行された実際の API キーに置き換えてください。
+- `OPENAI_MODEL` は利用する OpenAI モデルを指定します。省略時は `o3-mini` が使
+用されます。
+- `REASONING_EFFORT` は API 呼び出し時の `reasoning_effort` パラメータを指定します。
+- `GIT_AUTO_COMMIT` は Git 自動コミットを行うかどうかの設定です。デフォルトは `false` で、必要に応じて `true` に設定してください。
 - 必要に応じて `LOG_DIR` や `HTML_DIR` を上書きできますが、指定がない場合はデフォルトで `gen/log` および `gen/html` が使用されます。
 
 ### 4.2. 自己署名証明書の作成

--- a/server.js
+++ b/server.js
@@ -26,6 +26,10 @@ app.use(express.static('public'));
 const logDir = process.env.LOG_DIR ? path.resolve(process.env.LOG_DIR) : path.join(__dirname, 'gen', 'log');
 const htmlDir = process.env.HTML_DIR ? path.resolve(process.env.HTML_DIR) : path.join(__dirname, 'gen', 'html');
 
+// OpenAI API 設定（.env から読み込み、指定がなければデフォルト値を利用）
+const openAiModel = process.env.OPENAI_MODEL || 'o3-mini';
+const reasoningEffort = process.env.REASONING_EFFORT || 'high';
+
 // 必要なディレクトリが存在しなければ再帰的に作成
 if (!fs.existsSync(logDir)) {
   fs.mkdirSync(logDir, { recursive: true });
@@ -180,10 +184,10 @@ app.post('/chat', async (req, res) => {
     
     // API に送信するペイロードの作成
     const payload = {
-      model: 'o3-mini',
+      model: openAiModel,
       messages: messages,
-      reasoning_effort: 'high',
-      response_format: {'type':'json_object'}  // 戻り値を JSON オブジェクトとして指定
+      reasoning_effort: reasoningEffort,
+      response_format: { type: 'json_object' }  // 戻り値を JSON オブジェクトとして指定
     };
     
     console.log("Sending API request with payload:", payload);


### PR DESCRIPTION
## Summary
- load `OPENAI_MODEL` and `REASONING_EFFORT` from `.env`
- update README to document the new variables

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6841161758408322ad29ab4f38ea04a2